### PR TITLE
feat(stories,api,admin,ui): robust stories endpoints, server-rendered…

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,75 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import Link from "next/link"
+import { Navigation } from "@/components/layout/navigation"
+import { Footer } from "@/components/layout/footer"
+import { Badge } from "@/components/ui/badge"
+
+export default function AboutPage() {
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    setTimeout(() => setIsVisible(true), 120)
+  }, [])
+
+  return (
+    <main className="min-h-screen bg-white">
+      <Navigation />
+
+      <section className="relative py-20">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="max-w-5xl mx-auto text-center">
+            <div className={`mb-6 transition-all duration-700 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-6'}`}>
+              <Badge className="mb-4 bg-[#1A7B7B] text-white">About Us</Badge>
+              <h1 className="text-4xl sm:text-5xl font-bold text-gray-900 mb-4">About Culture & Tourism CDS</h1>
+              <p className="text-lg text-gray-600 max-w-3xl mx-auto">We empower NYSC corps members to document and promote Jos's cultural heritage through community-driven tourism initiatives, storytelling, and events.</p>
+            </div>
+
+            <div className="grid md:grid-cols-2 gap-8 mt-12">
+              <div className={`transition-all duration-700 ${isVisible ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-6'}`}>
+                <h3 className="text-2xl font-semibold mb-4">Our Mission</h3>
+                <p className="text-gray-700 mb-4">To preserve, celebrate, and share Plateau State's cultural heritage while creating sustainable tourism opportunities that benefit local communities and corps members.</p>
+                <h3 className="text-2xl font-semibold mb-4">What We Do</h3>
+                <ul className="list-disc list-inside text-gray-700 space-y-2">
+                  <li>Document cultural sites and oral histories</li>
+                  <li>Organize community events and tours</li>
+                  <li>Train corps members in responsible tourism</li>
+                  <li>Share stories that inspire visitors and locals</li>
+                </ul>
+              </div>
+
+              <div className={`transition-all duration-700 ${isVisible ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-6'}`}>
+                <div className="rounded-3xl overflow-hidden shadow-lg">
+                  <img src="/national-museum-jos-cultural-artifacts.jpg" alt="National Museum" className="w-full h-64 object-cover" />
+                </div>
+                <div className="mt-6 grid grid-cols-3 gap-4 text-center">
+                  <div>
+                    <div className="text-3xl font-bold text-gray-900">500+</div>
+                    <div className="text-sm text-gray-600">Active Corps Members</div>
+                  </div>
+                  <div>
+                    <div className="text-3xl font-bold text-gray-900">100+</div>
+                    <div className="text-sm text-gray-600">Documented Sites</div>
+                  </div>
+                  <div>
+                    <div className="text-3xl font-bold text-gray-900">200+</div>
+                    <div className="text-sm text-gray-600">Stories Shared</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-12">
+              <Link href="/auth/signup">
+                <button className="bg-[#1A7B7B] text-white px-10 py-3 rounded-full font-semibold hover:bg-[#156666] transition-all duration-300">Join the Community</button>
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <Footer />
+    </main>
+  )
+}

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,15 +1,14 @@
 import type React from "react"
 import type { Metadata } from "next"
+import AdminLayoutWrapper from "@/components/admin/admin-layout-wrapper"
 
 export const metadata: Metadata = {
   title: "Admin Dashboard - Jos Culture & Tourism",
   description: "Administrative panel for managing the Jos Culture & Tourism CDS Platform",
 }
 
-export default function AdminLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
-  return <>{children}</>
+// Server component layout: it exports `metadata` and renders a client-side
+// wrapper which contains authentication guards and client-only UI.
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  return <AdminLayoutWrapper currentPath="/admin">{children}</AdminLayoutWrapper>
 }

--- a/app/admin/stories/page.tsx
+++ b/app/admin/stories/page.tsx
@@ -52,6 +52,15 @@ export default function StoriesPage() {
   // author/profile resolution removed
 
   useEffect(() => {
+    // Avoid calling admin APIs when not logged in as admin in the browser.
+    if (typeof window !== "undefined") {
+      const adminSession = localStorage.getItem("admin_session")
+      if (!adminSession || adminSession !== "true") {
+        setLoading(false)
+        return
+      }
+    }
+
     fetchStories()
   }, [])
 

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -165,7 +165,7 @@ export default function LoginPage() {
               </Button>
             </form>
 
-            <div className="mt-6 text-center text-sm text-gray-600">
+            {/* <div className="mt-6 text-center text-sm text-gray-600">
               Don't have an account?{" "}
               <Link
                 href="/auth/signup"
@@ -173,7 +173,7 @@ export default function LoginPage() {
               >
                 Sign up here
               </Link>
-            </div>
+            </div> */}
           </CardContent>
         </Card>
 

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,45 @@
+import Link from 'next/link'
+import { Navigation } from '@/components/layout/navigation'
+import { Footer } from '@/components/layout/footer'
+
+export default function NotFound() {
+  return (
+    <main className="min-h-screen bg-background">
+      <Navigation />
+
+      <div className="flex flex-col items-center justify-center text-center py-24 px-4">
+        <div className="max-w-3xl">
+          <div className="mx-auto w-64 h-64">
+            {/* Simple on-brand illustration: compass + broken path */}
+            <svg viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+              <rect width="200" height="200" rx="24" fill="#E6FFFA" />
+              <g transform="translate(40,40)">
+                <circle cx="60" cy="60" r="38" fill="#0F766E" opacity="0.08" />
+                <path d="M58 28 L72 40 L48 52 L34 40 Z" fill="#0F766E" />
+                <path d="M10 110 C30 80, 90 80, 110 110" stroke="#1A7B7B" strokeWidth="4" strokeLinecap="round" strokeDasharray="6 6" fill="none" />
+                <circle cx="8" cy="112" r="4" fill="#1A7B7B" />
+                <circle cx="112" cy="112" r="4" fill="#1A7B7B" />
+              </g>
+            </svg>
+          </div>
+
+          <h1 className="mt-8 text-3xl sm:text-4xl font-bold text-foreground">Page not found</h1>
+          <p className="mt-4 text-muted-foreground">We couldn't find the page you're looking for. It may have moved or no longer exists.</p>
+
+          <div className="mt-8 flex items-center justify-center gap-4">
+            <Link href="/" className="inline-flex items-center gap-2 px-5 py-3 rounded-full bg-[#1A7B7B] text-white font-semibold hover:bg-[#156666] transition">
+              Home
+            </Link>
+            <Link href="/stories" className="inline-flex items-center gap-2 px-5 py-3 rounded-full border border-[#1A7B7B] text-[#1A7B7B] hover:bg-[#1A7B7B] hover:text-white transition">
+              Browse Stories
+            </Link>
+          </div>
+
+          <p className="mt-6 text-sm text-muted-foreground">If you followed a broken link, please let us know — or try searching from the navigation.</p>
+        </div>
+      </div>
+
+      <Footer />
+    </main>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -427,46 +427,7 @@ export default function HomePage() {
         </div>
       </section>
 
-       {/* Featured CDS Stories (replaces Featured Upcoming Events) */}
-      <section
-        ref={eventsRef}
-        className={`py-20 bg-gradient-to-b from-gray-50 to-white transition-all duration-1200 ease-out ${
-          eventsVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-20"
-        }`}
-      >
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="max-w-6xl mx-auto">
-            <div
-              className={`text-center mb-16 transition-all duration-1000 ${
-                eventsVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
-              }`}
-            >
-              <h2 className="text-4xl sm:text-5xl font-bold text-gray-900 mb-4">Corps Stories</h2>
-              <div
-                className="w-24 h-1 bg-[#1A7B7B] mx-auto mb-6 transition-all duration-700 delay-200"
-                style={{ width: eventsVisible ? "96px" : "0px" }}
-              ></div>
-              <p className="text-xl text-gray-600 max-w-3xl mx-auto">Recent stories shared by corps members</p>
-            </div>
-
-            {/* Stories grid will be populated via client fetch of admin stories */}
-            <StoriesGrid visible={eventsVisible} />
-
-            {/* View All Stories Button */}
-            <div
-              className={`text-center mt-12 transition-all duration-800 delay-600 ${
-                eventsVisible ? "opacity-100 scale-100 translate-y-0" : "opacity-0 scale-90 translate-y-10"
-              }`}
-            >
-              <Link href="/stories">
-                <button className="bg-white border-2 border-[#1A7B7B] text-[#1A7B7B] px-10 py-4 rounded-full text-lg font-semibold hover:bg-[#1A7B7B] hover:text-white transition-all duration-500 shadow-lg hover:shadow-xl transform hover:-translate-y-2 duration-300">
-                  View All Stories
-                </button>
-              </Link>
-            </div>
-          </div>
-        </div>
-      </section>
+      
 
       {/* How It Works Section */}
       <section
@@ -555,7 +516,46 @@ export default function HomePage() {
       </section>
 
      
+ {/* Featured CDS Stories (replaces Featured Upcoming Events) */}
+      <section
+        ref={eventsRef}
+        className={`py-20 bg-gradient-to-b from-gray-50 to-white transition-all duration-1200 ease-out ${
+          eventsVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-20"
+        }`}
+      >
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="max-w-6xl mx-auto">
+            <div
+              className={`text-center mb-16 transition-all duration-1000 ${
+                eventsVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
+              }`}
+            >
+              <h2 className="text-4xl sm:text-5xl font-bold text-gray-900 mb-4">Corps Stories</h2>
+              <div
+                className="w-24 h-1 bg-[#1A7B7B] mx-auto mb-6 transition-all duration-700 delay-200"
+                style={{ width: eventsVisible ? "96px" : "0px" }}
+              ></div>
+              <p className="text-xl text-gray-600 max-w-3xl mx-auto">Recent stories shared by corps members</p>
+            </div>
 
+            {/* Stories grid will be populated via client fetch of admin stories */}
+            <StoriesGrid visible={eventsVisible} />
+
+            {/* View All Stories Button */}
+            <div
+              className={`text-center mt-12 transition-all duration-800 delay-600 ${
+                eventsVisible ? "opacity-100 scale-100 translate-y-0" : "opacity-0 scale-90 translate-y-10"
+              }`}
+            >
+              <Link href="/stories">
+                <button className="bg-white border-2 border-[#1A7B7B] text-[#1A7B7B] px-10 py-4 rounded-full text-lg font-semibold hover:bg-[#1A7B7B] hover:text-white transition-all duration-500 shadow-lg hover:shadow-xl transform hover:-translate-y-2 duration-300">
+                  View All Stories
+                </button>
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
      
 
        {/* Explore by Category Section */}

--- a/app/stories/[id]/page.tsx
+++ b/app/stories/[id]/page.tsx
@@ -1,0 +1,66 @@
+import { createClient } from '@/lib/supabase/server'
+import { storyDbSelect } from '@/lib/schemas/stories'
+import { notFound } from 'next/navigation'
+import { Navigation } from '@/components/layout/navigation'
+import { Footer } from '@/components/layout/footer'
+import Image from 'next/image'
+
+export default async function StoryDetailPage({ params }: { params: { id: string } }) {
+  const { id } = params
+  const supabase = await createClient()
+
+  try {
+    const { data, error } = await supabase
+      .from('stories')
+      .select(storyDbSelect)
+      .eq('id', id)
+      .single()
+
+    if (error || !data) {
+      console.debug('[stories/[id]] story not found', id, error)
+      return notFound()
+    }
+
+    const story: any = data
+
+    const images: string[] = Array.isArray(story.images)
+      ? story.images
+      : story.images
+      ? [story.images]
+      : story.cover_image
+      ? [story.cover_image]
+      : []
+
+    const content = story.summary || story.excerpt || story.body || ''
+
+    return (
+      <main className="min-h-screen bg-background">
+        <Navigation />
+
+        <div className="max-w-4xl mx-auto py-20 px-4 sm:px-6 lg:px-8">
+          <article className="prose lg:prose-xl">
+            <h1 className="text-4xl font-bold">{story.title}</h1>
+            <div className="text-sm text-muted-foreground">
+              {story.created_at ? new Date(story.created_at).toLocaleString() : ''}
+            </div>
+
+            {images.length > 0 && (
+              <div className="mt-6 mb-6">
+                <img src={images[0]} alt={story.title} className="w-full h-72 object-cover rounded-lg" />
+              </div>
+            )}
+
+            <div className="mt-6">
+              <div dangerouslySetInnerHTML={{ __html: content }} />
+            </div>
+          </article>
+        </div>
+
+        <Footer />
+      </main>
+    )
+  } catch (err) {
+    console.error('[stories/[id]] unexpected error', err)
+    return notFound()
+  }
+}

--- a/app/stories/page.tsx
+++ b/app/stories/page.tsx
@@ -1,485 +1,52 @@
-"use client"
-
-import { useState, useEffect, useRef } from "react"
+import { createClient } from "@/lib/supabase/server"
+import { storyDbSelect } from "@/lib/schemas/stories"
 import { Navigation } from "@/components/layout/navigation"
 import { Footer } from "@/components/layout/footer"
-import { StoryCard } from "@/components/stories/story-card"
-import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
-import { Input } from "@/components/ui/input"
-import { BreadcrumbNav } from "@/components/ui/breadcrumb-nav"
-import { NoStoriesFound } from "@/components/ui/empty-states"
-import { StoryCardSkeleton } from "@/components/ui/loading-states"
-import { Search, Plus, TrendingUp, Clock, Sparkles, Heart, Eye } from "lucide-react"
+import { StoriesClient } from "@/components/stories/stories-client"
 
-// stories fetched from the database (published only)
-// kept the previous static dataset in repository history for reference
-interface Story {
-  id: string
-  title: string
-  content: string
-  images?: string[]
-  location?: string
-  date?: string
-  likes?: number
-  comments?: number
-  tags?: string[]
-  isLiked?: boolean
-}
+// Server component: fetch initial published stories and pass to the client
+export default async function StoriesPage() {
+  const supabase = await createClient()
 
-const initialStories: Story[] = []
+  try {
+    const { data, error } = await supabase
+      .from("stories")
+      .select(storyDbSelect)
+      .eq("published", true)
+      .order("created_at", { ascending: false })
 
-const sortOptions = [
-  { value: "recent", label: "Most Recent", icon: Clock },
-  { value: "popular", label: "Most Popular", icon: TrendingUp },
-]
+    const safe = Array.isArray(data)
+      ? data.map((row: any) => ({
+          id: row.id != null ? String(row.id) : "",
+          title: row.title || "",
+          content: row.summary || row.excerpt || row.body || "",
+          images: Array.isArray(row.images)
+            ? row.images
+            : row.images
+            ? [row.images]
+            : row.cover_image
+            ? [row.cover_image]
+            : [],
+          date: row.created_at || row.published_at || null,
+          tags: Array.isArray(row.tags) ? row.tags : row.tags ? [row.tags] : [],
+        }))
+      : []
 
-const allTags = [
-  "wildlife",
-  "nature",
-  "culture",
-  "museum",
-  "hiking",
-  "adventure",
-  "CDS",
-  "community",
-  "market",
-  "traditional",
-]
-
-export default function StoriesPage() {
-  const [stories, setStories] = useState<Story[]>(initialStories)
-  const [filteredStories, setFilteredStories] = useState<Story[]>(initialStories)
-  const [searchQuery, setSearchQuery] = useState("")
-  const [sortBy, setSortBy] = useState("recent")
-  const [selectedTag, setSelectedTag] = useState<string | null>(null)
-  const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  const heroRef = useRef<HTMLDivElement>(null)
-  const storiesRef = useRef<HTMLDivElement>(null)
-  const [isHeroVisible, setIsHeroVisible] = useState(false)
-  const [isStoriesVisible, setIsStoriesVisible] = useState(false)
-
-  useEffect(() => {
-    const observerOptions = {
-      threshold: 0.1,
-      rootMargin: "0px 0px -100px 0px",
-    }
-
-    const heroObserver = new IntersectionObserver((entries) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          setIsHeroVisible(true)
-        }
-      })
-    }, observerOptions)
-
-    const storiesObserver = new IntersectionObserver((entries) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          setIsStoriesVisible(true)
-        }
-      })
-    }, observerOptions)
-
-    if (heroRef.current) heroObserver.observe(heroRef.current)
-    if (storiesRef.current) storiesObserver.observe(storiesRef.current)
-
-    return () => {
-      heroObserver.disconnect()
-      storiesObserver.disconnect()
-    }
-  }, [])
-
-  // Fetch published stories from the API on mount
-  useEffect(() => {
-    const controller = new AbortController()
-    let mounted = true
-    let pollTimer: number | null = null
-
-    const fetchStories = async (opts?: { signal?: AbortSignal }) => {
-      setIsLoading(true)
-      setError(null)
-      try {
-        const res = await fetch('/api/admin/stories', { signal: opts?.signal })
-        if (!res.ok) {
-          const txt = await res.text().catch(() => '')
-          throw new Error(txt || `Failed to fetch stories: ${res.status}`)
-        }
-        const raw = await res.json()
-        // Accept two shapes: either the public API returns an array, or
-        // some endpoints return { data: [] } (admin-style). Normalize to an array.
-        let data: Story[] = []
-        if (Array.isArray(raw)) {
-          data = raw
-        } else if (raw && Array.isArray((raw as any).data)) {
-          data = (raw as any).data
-        } else {
-          console.debug('[stories page] unexpected /api/stories response shape', raw)
-          data = []
-        }
-        if (!mounted) return
-        setStories(data)
-        // only replace filteredStories when there is no active search/tag
-        setFilteredStories((prev) => (!searchQuery && !selectedTag ? data : prev))
-        console.debug('[stories page] fetched stories count:', data?.length, data?.[0])
-      } catch (err: any) {
-        if (err?.name === 'AbortError') return
-        console.error('Failed to load stories', err)
-        setError(String(err?.message || err))
-      } finally {
-        if (mounted) setIsLoading(false)
-      }
-    }
-
-    // initial load
-    fetchStories({ signal: controller.signal })
-
-    // refetch on window focus so admin changes become visible quickly
-    const onFocus = () => {
-      // create a fresh controller for this one-off fetch
-      const c = new AbortController()
-      fetchStories({ signal: c.signal }).catch(() => {})
-    }
-
-    const onVisibility = () => {
-      if (document.visibilityState === 'visible') onFocus()
-    }
-
-    window.addEventListener('focus', onFocus)
-    window.addEventListener('visibilitychange', onVisibility)
-
-    // poll periodically (20s) for updates
-    pollTimer = window.setInterval(() => {
-      const c = new AbortController()
-      fetchStories({ signal: c.signal }).catch(() => {})
-    }, 20_000)
-
-    return () => {
-      mounted = false
-      controller.abort()
-      if (pollTimer) window.clearInterval(pollTimer)
-      window.removeEventListener('focus', onFocus)
-      window.removeEventListener('visibilitychange', onVisibility)
-    }
-  }, [])
-
-  // Keep filteredStories in sync with the main stories list when
-  // there is no active search query or tag filter. This ensures the
-  // Featured hero (derived from `stories`) and the All Stories list
-  // (derived from `filteredStories`) remain consistent.
-  useEffect(() => {
-    if (!searchQuery && !selectedTag) {
-      setFilteredStories(stories)
-    }
-  }, [stories, searchQuery, selectedTag])
-
-  const handleSearch = (query: string) => {
-    setSearchQuery(query)
-    setIsLoading(true)
-
-    setTimeout(() => {
-      let filtered = stories
-
-      if (query) {
-        const q = query.toLowerCase()
-        filtered = filtered.filter((story: Story) => {
-          const title = story.title?.toLowerCase() || ''
-          const content = story.content?.toLowerCase() || ''
-          const hasTag = (story.tags || []).some((tag: string) => tag.toLowerCase().includes(q))
-          const loc = story.location?.toLowerCase() || ''
-          return title.includes(q) || content.includes(q) || hasTag || loc.includes(q)
-        })
-      }
-
-      if (selectedTag) {
-        filtered = filtered.filter((story: Story) => (story.tags || []).includes(selectedTag))
-      }
-
-      setFilteredStories(filtered)
-      setIsLoading(false)
-    }, 300)
-  }
-
-  const handleTagFilter = (tag: string) => {
-    if (selectedTag === tag) {
-      setSelectedTag(null)
-      setFilteredStories(stories)
-    } else {
-      setSelectedTag(tag)
-      const filtered = stories.filter((story: Story) => (story.tags || []).includes(tag))
-      setFilteredStories(filtered)
-    }
-  }
-
-  const handleSort = (option: string) => {
-    setSortBy(option)
-    const sorted = [...filteredStories].sort((a: Story, b: Story) => {
-      if (option === "popular") {
-        return (b.likes || 0) - (a.likes || 0)
-      }
-      return (new Date(b.date || 0).getTime() || 0) - (new Date(a.date || 0).getTime() || 0)
-    })
-    setFilteredStories(sorted)
-  }
-
-  const totalLikes = stories.reduce((sum: number, story: Story) => sum + (story.likes || 0), 0)
-  const totalComments = stories.reduce((sum: number, story: Story) => sum + (story.comments || 0), 0)
-  const featuredStory = stories[0]
-
-  // If observer hasn't fired yet, but we already have stories, reveal the
-  // grid so users don't see an empty area. This keeps the animation when
-  // scrolling but avoids the content staying hidden after load.
-  const showStories = isStoriesVisible || filteredStories.length > 0
-  // Show a full-page loading state (same as admin) while the initial
-  // stories request is in-flight and no stories have been loaded yet.
-  if (isLoading && stories.length === 0) {
     return (
       <main className="min-h-screen bg-background">
         <Navigation />
-        <div className="min-h-screen flex items-center justify-center">
-          <div className="text-center">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto"></div>
-            <p className="mt-2 text-muted-foreground">Loading stories...</p>
-          </div>
-        </div>
+        <StoriesClient initialStories={safe} />
+        <Footer />
+      </main>
+    )
+  } catch (err) {
+    console.error('[stories page] server fetch failed', err)
+    return (
+      <main className="min-h-screen bg-background">
+        <Navigation />
+        <div className="min-h-[300px] flex items-center justify-center">Failed to load stories.</div>
         <Footer />
       </main>
     )
   }
-
-  return (
-    <main className="min-h-screen bg-background">
-      <Navigation />
-
-      <div
-        ref={heroRef}
-        className="relative pt-20 pb-16 bg-gradient-to-br from-[#1A7B7B] via-[#0F766E] to-[#1A7B7B] overflow-hidden"
-      >
-        {/* Background pattern */}
-        <div className="absolute inset-0 opacity-10">
-          <div
-            className="absolute inset-0"
-            style={{
-              backgroundImage: "radial-gradient(circle at 2px 2px, white 1px, transparent 0)",
-              backgroundSize: "40px 40px",
-            }}
-          />
-        </div>
-
-        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div
-            className={`text-center mb-12 transition-all duration-1000 ${
-              isHeroVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
-            }`}
-          >
-            <Badge className="mb-4 bg-white/20 text-white border-white/30 backdrop-blur-sm">
-              <Sparkles className="w-3 h-3 mr-1" />
-              Corps Stories
-            </Badge>
-            <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold text-white mb-4 text-balance">
-              Share Your Cultural Journey
-            </h1>
-            <p className="text-xl text-white/90 text-pretty max-w-3xl mx-auto mb-8">
-              Discover authentic experiences from corps members exploring Jos's rich cultural heritage
-            </p>
-
-            {/* Stats */}
-            <div className="flex items-center justify-center gap-8 mb-8">
-              <div className="text-center">
-                <div className="text-3xl font-bold text-white">{stories.length}</div>
-                <div className="text-sm text-white/80">Stories</div>
-              </div>
-              <div className="w-px h-12 bg-white/30" />
-              <div className="text-center">
-                <div className="text-3xl font-bold text-white">{totalLikes}</div>
-                <div className="text-sm text-white/80">Likes</div>
-              </div>
-              <div className="w-px h-12 bg-white/30" />
-              <div className="text-center">
-                <div className="text-3xl font-bold text-white">{totalComments}</div>
-                <div className="text-sm text-white/80">Comments</div>
-              </div>
-            </div>
-
-            <Button size="lg" className="bg-white text-[#1A7B7B] hover:bg-white/90 gap-2">
-              <Plus className="w-5 h-5" />
-              Share Your Story
-            </Button>
-          </div>
-
-          {/* Featured Story Preview */}
-          {featuredStory && (
-            <div
-              className={`max-w-4xl mx-auto transition-all duration-1000 delay-300 ${
-                isHeroVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
-              }`}
-            >
-              <div className="bg-white rounded-2xl shadow-2xl overflow-hidden">
-                <div className="grid md:grid-cols-2 gap-0">
-                  <div className="relative h-64 md:h-auto">
-                        <img
-                          src={(featuredStory.images && featuredStory.images.length > 0 ? featuredStory.images[0] : "/placeholder.svg")}
-                          alt={featuredStory.title || 'Featured story'}
-                          className="w-full h-full object-cover"
-                        />
-                    <div className="absolute top-4 left-4">
-                      <Badge className="bg-[#1A7B7B] text-white">Featured Story...</Badge>
-                    </div>
-                  </div>
-                  <div className="p-8 flex flex-col justify-center">
-                    <h3 className="text-2xl font-bold text-foreground mb-3">{featuredStory.title}</h3>
-                    <p className="text-muted-foreground mb-4 line-clamp-3">{featuredStory.content}</p>
-                    <div className="flex items-center gap-4 mb-4">
-                      <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                        <Heart className="w-4 h-4" />
-                        <span>{featuredStory.likes}</span>
-                      </div>
-                      <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                        <Eye className="w-4 h-4" />
-                        <span>{featuredStory.comments} comments</span>
-                      </div>
-                    </div>
-                    <Button className="w-fit bg-[#1A7B7B] hover:bg-[#0F766E]">Read Full Story</Button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          )}
-        </div>
-      </div>
-
-      <div className="py-16">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <BreadcrumbNav className="mb-8" />
-
-          <div className="mb-12">
-            <div className="flex flex-col lg:flex-row gap-6 mb-6">
-              <div className="relative flex-1">
-                <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 text-muted-foreground w-5 h-5" />
-                <Input
-                  placeholder="Search stories, experiences, locations..."
-                  value={searchQuery}
-                  onChange={(e) => handleSearch(e.target.value)}
-                  className="pl-12 h-14 text-base border-2 focus:border-[#1A7B7B]"
-                />
-              </div>
-              <div className="flex gap-3">
-                {sortOptions.map((option) => (
-                  <Button
-                    key={option.value}
-                    variant={sortBy === option.value ? "default" : "outline"}
-                    size="lg"
-                    onClick={() => handleSort(option.value)}
-                    className={`gap-2 ${sortBy === option.value ? "bg-[#1A7B7B] hover:bg-[#0F766E]" : ""}`}
-                  >
-                    <option.icon className="w-4 h-4" />
-                    <span className="hidden sm:inline">{option.label}</span>
-                  </Button>
-                ))}
-              </div>
-            </div>
-
-            <div className="flex flex-wrap gap-2">
-              <span className="text-sm font-medium text-muted-foreground flex items-center">Filter by tag:</span>
-              {allTags.map((tag) => (
-                <Badge
-                  key={tag}
-                  variant={selectedTag === tag ? "default" : "outline"}
-                  className={`cursor-pointer transition-all hover:scale-105 ${
-                    selectedTag === tag ? "bg-[#1A7B7B] hover:bg-[#0F766E] text-white" : "hover:border-[#1A7B7B]"
-                  }`}
-                  onClick={() => handleTagFilter(tag)}
-                >
-                  #{tag}
-                </Badge>
-              ))}
-              {selectedTag && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => {
-                      setSelectedTag(null)
-                      setFilteredStories(stories)
-                    }}
-                    className="h-6 text-xs"
-                  >
-                    Clear filter
-                  </Button>
-              )}
-            </div>
-          </div>
-
-          <div className="flex items-center justify-between mb-8">
-            <h2 className="text-2xl font-bold text-foreground">
-              {selectedTag ? `Stories tagged with #${selectedTag}` : "All Stories..."}
-            </h2>
-            <div className="text-sm text-muted-foreground bg-muted px-4 py-2 rounded-full">
-              {isLoading
-                ? "Loading..."
-                : `${filteredStories.length} ${filteredStories.length === 1 ? "story" : "stories"}`}
-            </div>
-          </div>
-
-          {isLoading ? (
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-12">
-              {Array.from({ length: 4 }).map((_, i) => (
-                <StoryCardSkeleton key={i} />
-              ))}
-            </div>
-          ) : (
-            <>
-              {error && (
-                <div className="mb-6 p-4 rounded-md bg-red-50 border border-red-200 text-red-900">
-                  Failed to load stories: {error}
-                </div>
-              )}
-              {!error && stories.length === 0 && (
-                <div className="mb-6 p-4 rounded-md bg-amber-50 border border-amber-200 text-amber-900">
-                  No published stories were found. If you expect stories to appear, check that the story rows have status="published" and that `cover_image`/`image_url` fields are populated. Visit the <a href="/admin/stories" className="underline">admin stories</a> page to review.
-                </div>
-              )}
-              <div
-                ref={storiesRef}
-                className={`grid grid-cols-1 lg:grid-cols-2 gap-8 mb-12 transition-all duration-1000 ${
-                  showStories ? "opacity-100" : "opacity-0"
-                }`}
-              >
-                {filteredStories.map((story, index) => (
-                  <div
-                    key={story.id}
-                    className="transition-all duration-700"
-                    style={{
-                      transitionDelay: showStories ? `${index * 100}ms` : "0ms",
-                      opacity: showStories ? 1 : 0,
-                      transform: showStories ? "translateY(0)" : "translateY(30px)",
-                    }}
-                  >
-                    <StoryCard story={story} />
-                  </div>
-                ))}
-              </div>
-
-              {filteredStories.length === 0 && <NoStoriesFound />}
-            </>
-          )}
-
-          {filteredStories.length > 0 && !isLoading && (
-            <div className="text-center">
-              <Button
-                variant="outline"
-                size="lg"
-                className="border-2 border-[#1A7B7B] text-[#1A7B7B] hover:bg-[#1A7B7B] hover:text-white transition-all bg-transparent"
-              >
-                Load More Stories
-              </Button>
-            </div>
-          )}
-        </div>
-      </div>
-
-      <Footer />
-    </main>
-  )
 }

--- a/components/admin/admin-layout-wrapper.tsx
+++ b/components/admin/admin-layout-wrapper.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+import React from "react"
+import { AdminLayout as UIAdminLayout } from "@/components/admin/admin-layout"
+import { ProtectedRoute } from "@/components/admin/protected-route"
+
+export default function AdminLayoutWrapper({ children, currentPath }: { children: React.ReactNode; currentPath?: string }) {
+  return (
+    <ProtectedRoute>
+      <UIAdminLayout currentPath={currentPath}>{children}</UIAdminLayout>
+    </ProtectedRoute>
+  )
+}

--- a/components/admin/content-management.tsx
+++ b/components/admin/content-management.tsx
@@ -48,6 +48,17 @@ export function ContentManagement() {
   const { toast } = useToast()
 
   useEffect(() => {
+    // Don't attempt to fetch admin APIs when there is no local admin session.
+    // This prevents anonymous visitors (or background tabs) from triggering
+    // repeated 401 requests on the server.
+    if (typeof window !== "undefined") {
+      const adminSession = localStorage.getItem("admin_session")
+      if (!adminSession || adminSession !== "true") {
+        setLoading(false)
+        return
+      }
+    }
+
     fetchStories()
   }, [])
 

--- a/components/admin/protected-route.tsx
+++ b/components/admin/protected-route.tsx
@@ -3,7 +3,7 @@
 import type React from "react"
 
 import { useEffect, useState } from "react"
-import { useRouter } from "next/navigation"
+import { useRouter, usePathname } from "next/navigation"
 import { Loader2 } from "lucide-react"
 
 interface ProtectedRouteProps {
@@ -15,6 +15,7 @@ export function ProtectedRoute({ children, requireAdmin = false }: ProtectedRout
   const [isLoading, setIsLoading] = useState(true)
   const [isAuthorized, setIsAuthorized] = useState(false)
   const router = useRouter()
+  const pathname = usePathname()
 
   useEffect(() => {
     const checkAuth = async () => {
@@ -28,8 +29,20 @@ export function ProtectedRoute({ children, requireAdmin = false }: ProtectedRout
       console.log("[v0] Admin username:", adminUsername)
       console.log("[v0] Login time:", loginTime)
 
+      // If we're on the login page, allow it to render so users can sign in.
       if (!adminSession || adminSession !== "true" || !adminUsername) {
-        console.log("[v0] ✗ No valid admin session found, redirecting to login")
+        console.log("[v0] ✗ No valid admin session found")
+
+        // If the current path is the login page, stop loading and allow the
+        // login UI to render. Otherwise redirect to the login page.
+        if (pathname && pathname.startsWith("/admin/login")) {
+          setIsLoading(false)
+          return
+        }
+
+        // Not on login page: navigate to login and clear loading so the
+        // UI doesn't remain stuck in the verifying state.
+        setIsLoading(false)
         router.push("/admin/login")
         return
       }

--- a/components/admin/stories-list.tsx
+++ b/components/admin/stories-list.tsx
@@ -23,6 +23,12 @@ export default function StoriesList({ onChange }: { onChange?: () => void }) {
   }
 
   useEffect(() => {
+    // Only fetch admin resources when an admin session exists in localStorage.
+    if (typeof window !== "undefined") {
+      const adminSession = localStorage.getItem("admin_session")
+      if (!adminSession || adminSession !== "true") return
+    }
+
     fetchList()
   }, [])
 

--- a/components/stories/stories-client.tsx
+++ b/components/stories/stories-client.tsx
@@ -1,0 +1,374 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { StoryCard } from "@/components/stories/story-card"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Input } from "@/components/ui/input"
+import { BreadcrumbNav } from "@/components/ui/breadcrumb-nav"
+import { NoStoriesFound } from "@/components/ui/empty-states"
+import { StoryCardSkeleton } from "@/components/ui/loading-states"
+import { Search, Plus, TrendingUp, Clock, Sparkles, Heart, Eye } from "lucide-react"
+
+interface Story {
+  id: string
+  title: string
+  content: string
+  images?: string[]
+  location?: string
+  date?: string
+  likes?: number
+  comments?: number
+  tags?: string[]
+  isLiked?: boolean
+}
+
+const sortOptions = [
+  { value: "recent", label: "Most Recent", icon: Clock },
+  { value: "popular", label: "Most Popular", icon: TrendingUp },
+]
+
+const allTags = [
+  "wildlife",
+  "nature",
+  "culture",
+  "museum",
+  "hiking",
+  "adventure",
+  "CDS",
+  "community",
+  "market",
+  "traditional",
+]
+
+export function StoriesClient({ initialStories }: { initialStories: Story[] }) {
+  const [stories, setStories] = useState<Story[]>(initialStories || [])
+  const [filteredStories, setFilteredStories] = useState<Story[]>(initialStories || [])
+  const [searchQuery, setSearchQuery] = useState("")
+  const [sortBy, setSortBy] = useState("recent")
+  const [selectedTag, setSelectedTag] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error] = useState<string | null>(null)
+
+  const heroRef = useRef<HTMLDivElement>(null)
+  const storiesRef = useRef<HTMLDivElement>(null)
+  const [isHeroVisible, setIsHeroVisible] = useState(false)
+  const [isStoriesVisible, setIsStoriesVisible] = useState(false)
+
+  useEffect(() => {
+    const observerOptions = {
+      threshold: 0.1,
+      rootMargin: "0px 0px -100px 0px",
+    }
+
+    const heroObserver = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          setIsHeroVisible(true)
+        }
+      })
+    }, observerOptions)
+
+    const storiesObserver = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          setIsStoriesVisible(true)
+        }
+      })
+    }, observerOptions)
+
+    if (heroRef.current) heroObserver.observe(heroRef.current)
+    if (storiesRef.current) storiesObserver.observe(storiesRef.current)
+
+    return () => {
+      heroObserver.disconnect()
+      storiesObserver.disconnect()
+    }
+  }, [])
+
+  // Keep filteredStories in sync with the main stories list when
+  // there is no active search query or tag filter.
+  useEffect(() => {
+    if (!searchQuery && !selectedTag) {
+      setFilteredStories(stories)
+    }
+  }, [stories, searchQuery, selectedTag])
+
+  const handleSearch = (query: string) => {
+    setSearchQuery(query)
+    setIsLoading(true)
+
+    setTimeout(() => {
+      let filtered = stories
+
+      if (query) {
+        const q = query.toLowerCase()
+        filtered = filtered.filter((story: Story) => {
+          const title = story.title?.toLowerCase() || ''
+          const content = story.content?.toLowerCase() || ''
+          const hasTag = (story.tags || []).some((tag: string) => tag.toLowerCase().includes(q))
+          const loc = story.location?.toLowerCase() || ''
+          return title.includes(q) || content.includes(q) || hasTag || loc.includes(q)
+        })
+      }
+
+      if (selectedTag) {
+        filtered = filtered.filter((story: Story) => (story.tags || []).includes(selectedTag))
+      }
+
+      setFilteredStories(filtered)
+      setIsLoading(false)
+    }, 200)
+  }
+
+  const handleTagFilter = (tag: string) => {
+    if (selectedTag === tag) {
+      setSelectedTag(null)
+      setFilteredStories(stories)
+    } else {
+      setSelectedTag(tag)
+      const filtered = stories.filter((story: Story) => (story.tags || []).includes(tag))
+      setFilteredStories(filtered)
+    }
+  }
+
+  const handleSort = (option: string) => {
+    setSortBy(option)
+    const sorted = [...filteredStories].sort((a: Story, b: Story) => {
+      if (option === "popular") {
+        return (b.likes || 0) - (a.likes || 0)
+      }
+      return (new Date(b.date || 0).getTime() || 0) - (new Date(a.date || 0).getTime() || 0)
+    })
+    setFilteredStories(sorted)
+  }
+
+  const totalLikes = stories.reduce((sum: number, story: Story) => sum + (story.likes || 0), 0)
+  const totalComments = stories.reduce((sum: number, story: Story) => sum + (story.comments || 0), 0)
+  const featuredStory = stories[0]
+
+  const showStories = isStoriesVisible || filteredStories.length > 0
+
+  if (isLoading && stories.length === 0) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto"></div>
+          <p className="mt-2 text-muted-foreground">Loading stories...</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <div
+        ref={heroRef}
+        className="relative pt-20 pb-16 bg-gradient-to-br from-[#1A7B7B] via-[#0F766E] to-[#1A7B7B] overflow-hidden"
+      >
+        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div
+            className={`text-center mb-12 transition-all duration-1000 ${
+              isHeroVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
+            }`}
+          >
+            <Badge className="mb-4 bg-white/20 text-white border-white/30 backdrop-blur-sm">
+              <Sparkles className="w-3 h-3 mr-1" />
+              Corps Stories
+            </Badge>
+            <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold text-white mb-4 text-balance">
+              Share Your Cultural Journey
+            </h1>
+            <p className="text-xl text-white/90 text-pretty max-w-3xl mx-auto mb-8">
+              Discover authentic experiences from corps members exploring Jos's rich cultural heritage
+            </p>
+
+            <div className="flex items-center justify-center gap-8 mb-8">
+              <div className="text-center">
+                <div className="text-3xl font-bold text-white">{stories.length}</div>
+                <div className="text-sm text-white/80">Stories</div>
+              </div>
+              <div className="w-px h-12 bg-white/30" />
+              <div className="text-center">
+                <div className="text-3xl font-bold text-white">{totalLikes}</div>
+                <div className="text-sm text-white/80">Likes</div>
+              </div>
+              <div className="w-px h-12 bg-white/30" />
+              <div className="text-center">
+                <div className="text-3xl font-bold text-white">{totalComments}</div>
+                <div className="text-sm text-white/80">Comments</div>
+              </div>
+            </div>
+
+            <Button size="lg" className="bg-white text-[#1A7B7B] hover:bg-white/90 gap-2">
+              <Plus className="w-5 h-5" />
+              Share Your Story
+            </Button>
+          </div>
+
+          {featuredStory && (
+            <div
+              className={`max-w-4xl mx-auto transition-all duration-1000 delay-300 ${
+                isHeroVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
+              }`}
+            >
+              <div className="bg-white rounded-2xl shadow-2xl overflow-hidden">
+                <div className="grid md:grid-cols-2 gap-0">
+                  <div className="relative h-64 md:h-auto">
+                    <img
+                      src={(featuredStory.images && featuredStory.images.length > 0 ? featuredStory.images[0] : "/placeholder.svg")}
+                      alt={featuredStory.title || 'Featured story'}
+                      className="w-full h-full object-cover"
+                    />
+                    <div className="absolute top-4 left-4">
+                      <Badge className="bg-[#1A7B7B] text-white">Featured Story...</Badge>
+                    </div>
+                  </div>
+                  <div className="p-8 flex flex-col justify-center">
+                    <h3 className="text-2xl font-bold text-foreground mb-3">{featuredStory.title}</h3>
+                    <p className="text-muted-foreground mb-4 line-clamp-3">{featuredStory.content}</p>
+                    <div className="flex items-center gap-4 mb-4">
+                      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                        <Heart className="w-4 h-4" />
+                        <span>{featuredStory.likes}</span>
+                      </div>
+                      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                        <Eye className="w-4 h-4" />
+                        <span>{featuredStory.comments} comments</span>
+                      </div>
+                    </div>
+                    <Button className="w-fit bg-[#1A7B7B] hover:bg-[#0F766E]">Read Full Story</Button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="py-16">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <BreadcrumbNav className="mb-8" />
+
+          <div className="mb-12">
+            <div className="flex flex-col lg:flex-row gap-6 mb-6">
+              <div className="relative flex-1">
+                <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 text-muted-foreground w-5 h-5" />
+                <Input
+                  placeholder="Search stories, experiences, locations..."
+                  value={searchQuery}
+                  onChange={(e) => handleSearch(e.target.value)}
+                  className="pl-12 h-14 text-base border-2 focus:border-[#1A7B7B]"
+                />
+              </div>
+              <div className="flex gap-3">
+                {sortOptions.map((option) => (
+                  <Button
+                    key={option.value}
+                    variant={sortBy === option.value ? "default" : "outline"}
+                    size="lg"
+                    onClick={() => handleSort(option.value)}
+                    className={`gap-2 ${sortBy === option.value ? "bg-[#1A7B7B] hover:bg-[#0F766E]" : ""}`}
+                  >
+                    <option.icon className="w-4 h-4" />
+                    <span className="hidden sm:inline">{option.label}</span>
+                  </Button>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <span className="text-sm font-medium text-muted-foreground flex items-center">Filter by tag:</span>
+              {allTags.map((tag) => (
+                <Badge
+                  key={tag}
+                  variant={selectedTag === tag ? "default" : "outline"}
+                  className={`cursor-pointer transition-all hover:scale-105 ${
+                    selectedTag === tag ? "bg-[#1A7B7B] hover:bg-[#0F766E] text-white" : "hover:border-[#1A7B7B]"
+                  }`}
+                  onClick={() => handleTagFilter(tag)}
+                >
+                  #{tag}
+                </Badge>
+              ))}
+              {selectedTag && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setSelectedTag(null)
+                    setFilteredStories(stories)
+                  }}
+                  className="h-6 text-xs"
+                >
+                  Clear filter
+                </Button>
+              )}
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between mb-8">
+            <h2 className="text-2xl font-bold text-foreground">
+              {selectedTag ? `Stories tagged with #${selectedTag}` : "All Stories..."}
+            </h2>
+            <div className="text-sm text-muted-foreground bg-muted px-4 py-2 rounded-full">
+              {isLoading
+                ? "Loading..."
+                : `${filteredStories.length} ${filteredStories.length === 1 ? "story" : "stories"}`}
+            </div>
+          </div>
+
+          {isLoading ? (
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-12">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <StoryCardSkeleton key={i} />
+              ))}
+            </div>
+          ) : (
+            <>
+              {!error && stories.length === 0 && (
+                <div className="mb-6 p-4 rounded-md bg-amber-50 border border-amber-200 text-amber-900">
+                  No published stories were found. If you expect stories to appear, check that the story rows have status="published" and that `cover_image`/`image_url` fields are populated. Visit the <a href="/admin/stories" className="underline">admin stories</a> page to review.
+                </div>
+              )}
+              <div
+                ref={storiesRef}
+                className={`grid grid-cols-1 lg:grid-cols-2 gap-8 mb-12 transition-all duration-1000 ${
+                  showStories ? "opacity-100" : "opacity-0"
+                }`}
+              >
+                {filteredStories.map((story, index) => (
+                  <div
+                    key={story.id}
+                    className="transition-all duration-700"
+                    style={{
+                      transitionDelay: showStories ? `${index * 100}ms` : "0ms",
+                      opacity: showStories ? 1 : 0,
+                      transform: showStories ? "translateY(0)" : "translateY(30px)",
+                    }}
+                  >
+                    <StoryCard story={story} />
+                  </div>
+                ))}
+              </div>
+
+              {filteredStories.length === 0 && <NoStoriesFound />}
+            </>
+          )}
+
+          {filteredStories.length > 0 && !isLoading && (
+            <div className="text-center">
+              <Button
+                variant="outline"
+                size="lg"
+                className="border-2 border-[#1A7B7B] text-[#1A7B7B] hover:bg-[#1A7B7B] hover:text-white transition-all bg-transparent"
+              >
+                Load More Stories
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/stories/stories-grid.tsx
+++ b/components/stories/stories-grid.tsx
@@ -25,13 +25,16 @@ export function StoriesGrid({ visible }: { visible?: boolean }) {
       setLoading(true)
       setError(null)
       try {
-        const res = await fetch('/api/admin/stories')
+        // Use the public stories endpoint for client pages to avoid hitting
+        // admin/service-role logic on the server.
+        const res = await fetch('/api/stories')
         if (!res.ok) {
           const txt = await res.text().catch(() => '')
-          throw new Error(txt || `Failed to fetch admin stories: ${res.status}`)
+          throw new Error(txt || `Failed to fetch stories: ${res.status}`)
         }
         const raw = await res.json()
-        const data = Array.isArray(raw?.data) ? raw.data : []
+        // Accept either an array (public endpoint) or { data: [] } (admin-style)
+        const data = Array.isArray(raw) ? raw : Array.isArray(raw?.data) ? raw.data : []
         if (!mounted) return
         setStories(
           data.map((row: any) => ({

--- a/components/stories/story-card.tsx
+++ b/components/stories/story-card.tsx
@@ -6,10 +6,11 @@ import { Badge } from "@/components/ui/badge"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Heart, MessageCircle, Share2, MapPin, Calendar, Bookmark } from "lucide-react"
 import { useState } from "react"
+import Link from "next/link"
 
 interface StoryCardProps {
   story: {
-    id: string
+    id: string | number
     title: string
     content: string
     images?: string[]
@@ -37,7 +38,8 @@ export function StoryCard({ story }: StoryCardProps) {
     setLikesCount(isLiked ? likesCount - 1 : likesCount + 1)
   }
 
-  const formatDate = (dateString: string) => {
+  const formatDate = (dateString?: string) => {
+    if (!dateString) return ''
     const date = new Date(dateString)
     const now = new Date()
     const diffTime = Math.abs(now.getTime() - date.getTime())
@@ -53,127 +55,152 @@ export function StoryCard({ story }: StoryCardProps) {
   const images = story.images ?? []
   const tags = story.tags ?? []
 
+  // determine if we have author info to show
+  const hasAuthor = Boolean(story.author && (story.author.name || story.author.avatar))
+
   return (
     <Card className="group hover:shadow-2xl transition-all duration-500 overflow-hidden border-2 hover:border-[#1A7B7B]/20 h-full flex flex-col">
-      <CardContent className="p-6 pb-0">
-        <div className="flex items-center gap-3 mb-4">
-          <Avatar className="w-12 h-12 ring-2 ring-[#1A7B7B]/20">
-            <AvatarImage src={story.author?.avatar || "/placeholder.svg"} alt={story.author?.name || 'User'} />
-            <AvatarFallback className="bg-[#1A7B7B] text-white">
-              {(story.author?.name || 'U')
-                .split(" ")
-                .map((n) => n[0])
-                .join("")}
-            </AvatarFallback>
-          </Avatar>
-          <div className="flex-1">
-            <div className="flex items-center gap-2 mb-1">
-              <h4 className="font-semibold text-foreground">{story.author?.name || 'Unknown'}</h4>
-              <Badge variant="outline" className="text-xs border-[#1A7B7B]/30 text-[#1A7B7B]">
-                {story.author?.corpsId || ''}
-              </Badge>
-            </div>
-            <div className="flex items-center gap-3 text-xs text-muted-foreground">
-              <div className="flex items-center gap-1">
-                <MapPin className="w-3 h-3" />
-                <span>{story.location || ''}</span>
-              </div>
-              <div className="flex items-center gap-1">
-                <Calendar className="w-3 h-3" />
-                <span>{formatDate(story.date || '')}</span>
-              </div>
-            </div>
-          </div>
-          <button
-            onClick={() => setIsBookmarked(!isBookmarked)}
-            className="p-2 hover:bg-muted rounded-full transition-colors"
-          >
-            <Bookmark
-              className={`w-5 h-5 ${isBookmarked ? "fill-[#1A7B7B] text-[#1A7B7B]" : "text-muted-foreground"}`}
-            />
-          </button>
-        </div>
-      </CardContent>
-
-      <CardContent className="p-6 pt-0 flex-1 flex flex-col">
-        <h3 className="text-xl font-bold text-foreground mb-3 group-hover:text-[#1A7B7B] transition-colors">
-          {story.title}
-        </h3>
-        <p className="text-muted-foreground mb-4 leading-relaxed line-clamp-3 flex-1">{story.content}</p>
-
-        {images.length > 0 && (
-          <div className="mb-4">
-            {images.length === 1 ? (
-              <div className="relative overflow-hidden rounded-xl group/image">
-                <img
-                  src={images[0] || "/placeholder.svg"}
-                  alt="Story image"
-                  className="w-full h-72 object-cover transition-transform duration-500 group-hover/image:scale-110"
-                />
-                <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover/image:opacity-100 transition-opacity duration-300" />
-              </div>
-            ) : (
-              <div className="grid grid-cols-2 gap-2">
-                {images.slice(0, 4).map((image, index) => (
-                  <div key={index} className="relative overflow-hidden rounded-lg group/image">
-                    <img
-                      src={image || "/placeholder.svg"}
-                      alt={`Story image ${index + 1}`}
-                      className="w-full h-40 object-cover transition-transform duration-500 group-hover/image:scale-110"
-                    />
-                    {index === 3 && images.length > 4 && (
-                      <div className="absolute inset-0 bg-black/60 rounded-lg flex items-center justify-center backdrop-blur-sm">
-                        <span className="text-white font-bold text-xl">+{images.length - 4}</span>
-                      </div>
-                    )}
+      <Link href={`/stories/${story.id}`} className="no-underline text-inherit">
+        <CardContent className="p-6 pb-0">
+          <div className="flex items-center gap-3 mb-4">
+            {hasAuthor ? (
+              <>
+                <Avatar className="w-12 h-12 ring-2 ring-[#1A7B7B]/20">
+                  {story.author?.avatar ? (
+                    <AvatarImage src={story.author.avatar} alt={story.author?.name || 'User'} />
+                  ) : (
+                    <AvatarFallback className="bg-[#1A7B7B] text-white">
+                      {(story.author?.name || 'U')
+                        .split(" ")
+                        .map((n) => n[0])
+                        .join("")}
+                    </AvatarFallback>
+                  )}
+                </Avatar>
+                <div className="flex-1">
+                  <div className="flex items-center gap-2 mb-1">
+                    <h4 className="font-semibold text-foreground">{story.author?.name}</h4>
+                    <Badge variant="outline" className="text-xs border-[#1A7B7B]/30 text-[#1A7B7B]">
+                      {story.author?.corpsId || ''}
+                    </Badge>
                   </div>
-                ))}
+                  <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                    <div className="flex items-center gap-1">
+                      <MapPin className="w-3 h-3" />
+                      <span>{story.location || ''}</span>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <Calendar className="w-3 h-3" />
+                      <span>{formatDate(story.date)}</span>
+                    </div>
+                  </div>
+                </div>
+              </>
+            ) : (
+              <div className="flex-1">
+                <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                  <div className="flex items-center gap-1">
+                    <MapPin className="w-3 h-3" />
+                    <span>{story.location || ''}</span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <Calendar className="w-3 h-3" />
+                    <span>{formatDate(story.date)}</span>
+                  </div>
+                </div>
               </div>
             )}
-          </div>
-        )}
-        {tags.length > 0 && (
-          <div className="flex flex-wrap gap-2 mb-4">
-            {tags.map((tag, index) => (
-              <Badge
-                key={index}
-                variant="outline"
-                className="text-xs hover:bg-[#1A7B7B] hover:text-white hover:border-[#1A7B7B] transition-all cursor-pointer"
-              >
-                #{tag}
-              </Badge>
-            ))}
-          </div>
-        )}
 
-        <div className="flex items-center justify-between pt-4 border-t-2 border-border">
-          <div className="flex items-center gap-6">
             <button
-              onClick={handleLike}
-              className="flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-[#1A7B7B] transition-all group/like"
+              onClick={(e) => {
+                e.preventDefault()
+                setIsBookmarked(!isBookmarked)
+              }}
+              className="p-2 hover:bg-muted rounded-full transition-colors"
             >
-              <Heart
-                className={`w-5 h-5 transition-all ${isLiked ? "text-red-500 fill-current scale-110" : "group-hover/like:scale-110"}`}
+              <Bookmark
+                className={`w-5 h-5 ${isBookmarked ? "fill-[#1A7B7B] text-[#1A7B7B]" : "text-muted-foreground"}`}
               />
-              <span>{likesCount}</span>
-            </button>
-            <button className="flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-[#1A7B7B] transition-all group/comment">
-              <MessageCircle className="w-5 h-5 group-hover/comment:scale-110 transition-transform" />
-              <span>{story.comments}</span>
-            </button>
-            <button className="flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-[#1A7B7B] transition-all group/share">
-              <Share2 className="w-5 h-5 group-hover/share:scale-110 transition-transform" />
             </button>
           </div>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="font-semibold text-[#1A7B7B] hover:bg-[#1A7B7B] hover:text-white transition-all"
-          >
-            Read More
-          </Button>
-        </div>
-      </CardContent>
+        </CardContent>
+
+        <CardContent className="p-6 pt-0 flex-1 flex flex-col">
+          <h3 className="text-xl font-bold text-foreground mb-3 group-hover:text-[#1A7B7B] transition-colors">
+            {story.title}
+          </h3>
+          <p className="text-muted-foreground mb-4 leading-relaxed line-clamp-3 flex-1">{story.content}</p>
+
+          {images.length > 0 && (
+            <div className="mb-4">
+              {images.length === 1 ? (
+                <div className="relative overflow-hidden rounded-xl group/image">
+                  <img
+                    src={images[0] || "/placeholder.svg"}
+                    alt="Story image"
+                    className="w-full h-72 object-cover transition-transform duration-500 group-hover/image:scale-110"
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover/image:opacity-100 transition-opacity duration-300" />
+                </div>
+              ) : (
+                <div className="grid grid-cols-2 gap-2">
+                  {images.slice(0, 4).map((image, index) => (
+                    <div key={index} className="relative overflow-hidden rounded-lg group/image">
+                      <img
+                        src={image || "/placeholder.svg"}
+                        alt={`Story image ${index + 1}`}
+                        className="w-full h-40 object-cover transition-transform duration-500 group-hover/image:scale-110"
+                      />
+                      {index === 3 && images.length > 4 && (
+                        <div className="absolute inset-0 bg-black/60 rounded-lg flex items-center justify-center backdrop-blur-sm">
+                          <span className="text-white font-bold text-xl">+{images.length - 4}</span>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+          {tags.length > 0 && (
+            <div className="flex flex-wrap gap-2 mb-4">
+              {tags.map((tag, index) => (
+                <Badge
+                  key={index}
+                  variant="outline"
+                  className="text-xs hover:bg-[#1A7B7B] hover:text-white hover:border-[#1A7B7B] transition-all cursor-pointer"
+                >
+                  #{tag}
+                </Badge>
+              ))}
+            </div>
+          )}
+
+          <div className="flex items-center justify-between pt-4 border-t-2 border-border">
+            <div className="flex items-center gap-6">
+              <button
+                onClick={(e) => { e.preventDefault(); handleLike() }}
+                className="flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-[#1A7B7B] transition-all group/like"
+              >
+                <Heart
+                  className={`w-5 h-5 transition-all ${isLiked ? "text-red-500 fill-current scale-110" : "group-hover/like:scale-110"}`}
+                />
+                <span>{likesCount}</span>
+              </button>
+              <button className="flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-[#1A7B7B] transition-all group/comment">
+                <MessageCircle className="w-5 h-5 group-hover/comment:scale-110 transition-transform" />
+                <span>{story.comments}</span>
+              </button>
+              <button className="flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-[#1A7B7B] transition-all group/share">
+                <Share2 className="w-5 h-5 group-hover/share:scale-110 transition-transform" />
+              </button>
+            </div>
+            <Link href={`/stories/${story.id}`} legacyBehavior>
+              <a className="font-semibold text-[#1A7B7B] hover:bg-[#1A7B7B] hover:text-white transition-all px-4 py-2 rounded-md border border-transparent">Read More</a>
+            </Link>
+          </div>
+        </CardContent>
+      </Link>
     </Card>
   )
 }

--- a/components/ui/empty-states.tsx
+++ b/components/ui/empty-states.tsx
@@ -46,7 +46,7 @@ export function NoSitesFound() {
       description="We couldn't find any cultural sites matching your criteria. Try adjusting your filters or search terms."
       action={{
         label: "Clear Filters",
-        onClick: () => window.location.reload(),
+        onClick: () => window.dispatchEvent(new Event('cts:clear-filters')),
       }}
     />
   )
@@ -61,7 +61,7 @@ export function NoEventsFound() {
         Try adjusting your search terms or category filters to find more events.
       </p>
       <div className="flex gap-4 justify-center">
-        <Button onClick={() => window.location.reload()}>Clear Filters</Button>
+        <Button onClick={() => window.dispatchEvent(new Event('cts:clear-filters'))}>Clear Filters</Button>
         <Button variant="outline">
           <Plus className="w-4 h-4 mr-2" />
           Create Event
@@ -80,7 +80,7 @@ export function NoStoriesFound() {
         Try adjusting your search terms or be the first to share a story about this topic.
       </p>
       <div className="flex gap-4 justify-center">
-        <Button onClick={() => window.location.reload()}>Clear Search</Button>
+        <Button onClick={() => window.dispatchEvent(new Event('cts:clear-filters'))}>Clear Search</Button>
         <Button variant="outline">
           <Plus className="w-4 h-4 mr-2" />
           Share Your Story

--- a/lib/schemas/stories.ts
+++ b/lib/schemas/stories.ts
@@ -16,4 +16,15 @@ export type StoryCreate = z.infer<typeof storyCreateSchema>
 export type StoryUpdate = z.infer<typeof storyUpdateSchema>
 
 // Select used by admin endpoints to fetch story rows. author_id removed from select to avoid relying on that column.
-export const storyDbSelect = `id,title,slug,summary,body,excerpt,content,published,cover_image,image_url,category,status,is_featured,views_count,tags,state,location,created_at,updated_at`
+// Prioritized select: include the most essential and stable columns first,
+// followed by optional/legacy columns. This reduces the chance that
+// PostgREST will error about a missing column on the first attempt and
+// avoids repeated expensive retries.
+// NOTE: keep this list minimal and stable. Some deployments may not have
+// legacy columns like `content`; removing them prevents PostgREST errors
+// (42703) when a column is missing.
+// Keep this list intentionally minimal and stable. Columns like
+// `category`, `status`, `is_featured`, `views_count`, `tags`, `state`,
+// and `location` are optional in some deployments and caused 42703
+// errors at runtime. Only include the columns we expect to exist.
+export const storyDbSelect = `id,title,slug,summary,body,excerpt,published,created_at,updated_at,cover_image`


### PR DESCRIPTION
… pages, admin guards, and UI tweaks

- Stories: convert listing to server-side fetch + client StoriesClient; add story detail page and StoriesClient component; StoryCard refactor (linking, optional author UI, bookmark handling).
- API: consolidate story select (storyDbSelect) to a minimal, stable column list; public GET /api/stories made resilient with adaptive select trimming, missing-column recovery, and normalization of images/tags.
- Admin API: strengthen /api/admin/stories with server-side session check, in-memory select/result caching, fetch-with-timeout, core-select fast-path, and normalized responses.
- Admin UX: avoid calling admin endpoints from client when no local admin session (localStorage "admin_session") — applied in admin pages/components (content-management, stories page, stories-list, etc.) to reduce anonymous 401s.
- ProtectedRoute/Admin layout: import/use pathname to allow login page to render without redirect; add AdminLayoutWrapper and wrap admin layout with authentication guard.
- UI: empty-state "clear" actions now dispatch a 'cts:clear-filters' event instead of reloading the page.
- Misc: add About and NotFound pages; streamline story schema and select usage across codebase; small client/server stability and normalization changes.